### PR TITLE
Update keybindings to prevent clashes

### DIFF
--- a/keymaps/switch-note.json
+++ b/keymaps/switch-note.json
@@ -1,6 +1,6 @@
 {
   "body": {
-    "ctrl-shift-o": "switch-note:open",
-    "cmd-shift-o": "switch-note:open"
+    "ctrl-alt-o": "switch-note:open",
+    "cmd-alt-o": "switch-note:open"
   }
 }


### PR DESCRIPTION
Closes #3 

Uses `ctrl+alt+o` instead of `ctrl+shift+O`